### PR TITLE
Build a docker image to use for running bdcs-api-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM welder/bdcs-api-build-img:latest
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+COPY dist/build/bdcs-api-server/bdcs-api-server /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,14 @@ tests: sandbox
 	cabal build
 	cabal test --show-details=always
 
-ci:
-	sudo docker build -t welder/bdcs-api -f Dockerfile.build .
-	sudo docker run --rm --security-opt label=disable -v `pwd`:/bdcs-api/ welder/bdcs-api
+build-and-test: Dockerfile.build
+	sudo docker build -t welder/bdcs-api-build-img -f $< .
+	sudo docker run --rm --security-opt label=disable -v `pwd`:/bdcs-api/ welder/bdcs-api-build-img
+
+bdcs-api-img: build-and-test
+	sudo docker build -t welder/bdcs-api-img .
+
+ci: build-and-test
 
 ci_after_success:
 	sudo docker run --rm --security-opt label=disable -v `pwd`:/bdcs-api/ \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+STORE=$(realpath /mddb/"${STORE:-cs.repo}")
+MDDB="/mddb/${MDDB:-metadata.db}"
+RECIPES="${RECIPES:-/recipes/}"
+
+/usr/local/bin/bdcs-api-server --bdcs "$STORE" "$MDDB" "$RECIPES"


### PR DESCRIPTION
Changes the build image name to bdcs-api-build-img (consistent with the
naming for bdcs-build-img), and uses that as the basis for an image
running bdcs-api-server with default paths for mddb (/mddb), store
(/mddb/cs.repo/), and recipes (/recipes).

Requires a mddb and content store to be mounted by the run command.

sudo docker run -it --rm --security-opt="label=disable" \
-v bdcs-mddb-volume:/mddb/ -v $HOME/tmp/recipes:/recipes/ welder/bdcs-api-img