### PR TITLE
Fix docker container socket issue.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,5 @@ STORE=$(realpath /mddb/"${STORE:-cs.repo}")
 MDDB="/mddb/${MDDB:-metadata.db}"
 RECIPES="${RECIPES:-/recipes/}"
 
-/usr/local/bin/bdcs-api-server --bdcs "$STORE" "$MDDB" "$RECIPES"
+mkdir -p /run/weldr
+/usr/local/bin/bdcs-api-server -s /run/weldr/api.socket -g root --bdcs "$STORE" "$MDDB" "$RECIPES"


### PR DESCRIPTION
1. The bdcs-api docker image is able to work with domain socket.